### PR TITLE
fix arrayType equals method

### DIFF
--- a/src/java/net/kaleidos/hibernate/usertype/ArrayType.java
+++ b/src/java/net/kaleidos/hibernate/usertype/ArrayType.java
@@ -8,6 +8,7 @@ import org.hibernate.usertype.UserType;
 
 import java.io.Serializable;
 import java.sql.*;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -45,7 +46,8 @@ public class ArrayType implements UserType, ParameterizedType {
 
     @Override
     public boolean equals(Object x, Object y) throws HibernateException {
-        return x == null ? y == null : x.equals(y);
+        return x == null ? y == null : ((x.getClass().isArray() && y.getClass().isArray()) ?
+                Arrays.equals((Object[]) x, (Object[]) y) : x.equals(y));
     }
 
     @Override


### PR DESCRIPTION
In the ArrayType equals method comparison of array objects working wrongly.
